### PR TITLE
Fix issues when  we again insert B table2 and move C to the first table.

### DIFF
--- a/Lesson3/Exercise15/Exercise15.cpp
+++ b/Lesson3/Exercise15/Exercise15.cpp
@@ -99,7 +99,7 @@ public:
                 int old = data2[hash];
                 data2[hash] = key;
                 std::cout << "Inserted key " << key << " in table " << table << " by replacing " << old << std::endl;
-                insert_impl(old, cnt + 1, 2);
+                insert_impl(old, cnt + 1, 1);
             }
         }
     }


### PR DESCRIPTION
We still go ahead with inserting A and move B to the second hash table.this new position in the second hash table is also occupied, let's say by element C, we again insert B there and move C to the first table. 